### PR TITLE
Switch to imgui_bundle

### DIFF
--- a/moderngl_example.py
+++ b/moderngl_example.py
@@ -1,0 +1,40 @@
+import math
+import sys
+
+import moderngl
+import pygame
+from imgui_bundle import imgui
+from zengl_imgui import PygameBackend
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+pygame.display.set_caption("ModernGL + ImGui Example")
+
+impl = PygameBackend()
+
+imgui.get_io().ini_saving_rate = 0.0
+
+ctx = moderngl.get_context()
+
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+        impl.process_event(event)
+    impl.process_inputs()
+
+    imgui.new_frame()
+    imgui.show_demo_window()
+    imgui.end_frame()
+    imgui.render()
+
+    now = pygame.time.get_ticks() / 1000.0
+    r = math.sin(now + 0.0) * 0.5 + 0.5
+    g = math.sin(now + 2.1) * 0.5 + 0.5
+    b = math.sin(now + 4.2) * 0.5 + 0.5
+    ctx.clear(r, g, b)
+
+    impl.render()
+
+    pygame.display.flip()

--- a/pyopengl_example.py
+++ b/pyopengl_example.py
@@ -1,0 +1,39 @@
+import math
+import sys
+
+import pygame
+import OpenGL.GL as gl 
+from imgui_bundle import imgui
+from zengl_imgui import PygameBackend
+
+pygame.init()
+pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+pygame.display.set_caption("PyOpenGL + ImGui Example")
+
+impl = PygameBackend()
+
+imgui.get_io().ini_saving_rate = 0.0
+
+while True:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            pygame.quit()
+            sys.exit()
+        impl.process_event(event)
+    impl.process_inputs()
+
+    imgui.new_frame()
+    imgui.show_demo_window()
+    imgui.end_frame()
+    imgui.render()
+
+    now = pygame.time.get_ticks() / 1000.0
+    r = math.sin(now + 0.0) * 0.5 + 0.5
+    g = math.sin(now + 2.1) * 0.5 + 0.5
+    b = math.sin(now + 4.2) * 0.5 + 0.5
+    gl.glClearColor(r, g, b, 1.0)
+    gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+    impl.render()
+
+    pygame.display.flip()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='zengl-imgui',
-    version='1.0.0',
+    version='2.0.0',
     py_modules=['zengl_imgui'],
-    install_requires=['zengl', 'imgui'],
+    install_requires=['zengl', 'imgui_bundle'],
 )

--- a/zengl_example.py
+++ b/zengl_example.py
@@ -1,20 +1,23 @@
-import os
+import math
 import sys
 
-import imgui
 import pygame
 import zengl
-
+import zengl_extras
+from imgui_bundle import imgui
 from zengl_imgui import PygameBackend
 
-os.environ['SDL_WINDOWS_DPI_AWARENESS'] = 'permonitorv2'
-
+zengl_extras.init()
 pygame.init()
 pygame.display.set_mode((1280, 720), flags=pygame.OPENGL | pygame.DOUBLEBUF, vsync=True)
+pygame.display.set_caption("ZenGL + ImGui Example")
 
 impl = PygameBackend()
 
+imgui.get_io().ini_saving_rate = 0.0
+
 ctx = zengl.context()
+image = ctx.image(pygame.display.get_window_size(), 'rgba8unorm')
 
 while True:
     for event in pygame.event.get():
@@ -25,12 +28,22 @@ while True:
     impl.process_inputs()
 
     imgui.new_frame()
-    imgui.show_test_window()
+    imgui.show_demo_window()
     imgui.end_frame()
     imgui.render()
 
     ctx.new_frame()
-    impl.render()
+
+    now = pygame.time.get_ticks() / 1000.0
+    r = math.sin(now + 0.0) * 0.5 + 0.5
+    g = math.sin(now + 2.1) * 0.5 + 0.5
+    b = math.sin(now + 4.2) * 0.5 + 0.5
+    image.clear_value = (r, g, b, 1.0)
+
+    image.clear()
+    image.blit()
     ctx.end_frame()
+
+    impl.render()
 
     pygame.display.flip()

--- a/zengl_imgui.py
+++ b/zengl_imgui.py
@@ -180,6 +180,7 @@ class PygameBackend:
         # monkey patch fix for broken OpenGL backend import within imgui_bundle
         # we only care about the input/event handling from PygameRenderer
         # so we can safely just replace it with a noop
+        # (can remove once next imgui_bundle release is out)
         import sys, types
         _fake_mod = types.ModuleType("imgui_bundle.python_backends.opengl_backend_fixed")
         class FixedPipelineRenderer:
@@ -189,6 +190,8 @@ class PygameBackend:
 
         import pygame
         from imgui_bundle.python_backends.python_backends_disabled.pygame_backend import PygameRenderer
+        # once next imgui_bundle release is out, replace the above import with the below:
+        # from imgui_bundle.python_backends.pygame_backend import PygameRenderer
 
         class PygameInputHandler(PygameRenderer):
             def __init__(self):
@@ -199,6 +202,19 @@ class PygameBackend:
                 self.io = imgui.get_io()
                 self.io.display_size = pygame.display.get_window_size()
                 self._map_keys()
+
+                # patch a fix for imgui_bundle key mapping (can remove once next imgui_bundle release is out)
+                self.key_map.pop(pygame.K_SPACE, None)
+                self.key_map[pygame.K_TAB] = imgui.Key.tab
+
+            def _update_textures(self):
+                # replace PygameRenderer's texture refresh on-resize method with a noop
+                pass
+
+            def refresh_font_texture(self):
+                # current imgui_bundle version of `_update_textures`
+                # (can remove once next imgui_bundle release is out)
+                pass
 
         self.input_handler = PygameInputHandler()
         self.renderer = ZenGLRenderer()

--- a/zengl_imgui.py
+++ b/zengl_imgui.py
@@ -189,9 +189,11 @@ class PygameBackend:
         sys.modules["imgui_bundle.python_backends.opengl_backend_fixed"] = _fake_mod
 
         import pygame
-        from imgui_bundle.python_backends.python_backends_disabled.pygame_backend import PygameRenderer
-        # once next imgui_bundle release is out, replace the above import with the below:
-        # from imgui_bundle.python_backends.pygame_backend import PygameRenderer
+        try:
+            from imgui_bundle.python_backends.python_backends_disabled.pygame_backend import PygameRenderer
+        except ImportError:
+            # this will be the correct import path once the next imgui_bundle release is out
+            from imgui_bundle.python_backends.pygame_backend import PygameRenderer
 
         class PygameInputHandler(PygameRenderer):
             def __init__(self):

--- a/zengl_imgui.py
+++ b/zengl_imgui.py
@@ -1,7 +1,8 @@
 import struct
+from ctypes import c_byte
 
-import imgui
 import zengl
+from imgui_bundle import imgui
 
 
 class OpenGL:
@@ -47,8 +48,13 @@ class ZenGLRenderer:
         self.vertex_buffer = self.ctx.buffer(size=1)
         self.index_buffer = self.ctx.buffer(size=1, index=True)
 
-        width, height, pixels = self.io.fonts.get_tex_data_as_rgba32()
+        self.io.fonts.add_font_default()
+        tex_data = self.io.fonts.tex_data
+        width, height, pixels = tex_data.width, tex_data.height, tex_data.get_pixels_array()
         self.atlas = self.ctx.image((width, height), 'rgba8unorm', pixels)
+        tex_data.set_tex_id(zengl.inspect(self.atlas)['texture'])
+        tex_data.set_status(imgui.ImTextureStatus.ok)
+        self.io.backend_flags |= imgui.BackendFlags_.renderer_has_textures
 
         version = '#version 330 core'
         if 'WebGL' in self.ctx.info['version'] or 'OpenGL ES' in self.ctx.info['version']:
@@ -114,16 +120,29 @@ class ZenGLRenderer:
         self.gl = OpenGL()
         self.vtx_buffer = zengl.inspect(self.vertex_buffer)['buffer']
         self.idx_buffer = zengl.inspect(self.index_buffer)['buffer']
-        self.io.fonts.texture_id = zengl.inspect(self.atlas)['texture']
-        self.io.fonts.clear_tex_data()
+        self.ctx.end_frame(flush=False)
 
-    def render(self, draw_data=None):
+    def _update_font_texture(self):
+        tex_data = self.io.fonts.tex_data
+        pixels = self.io.fonts.tex_data.get_pixels_array()
+        self.atlas.write(pixels)
+        tex_data.set_tex_id(zengl.inspect(self.atlas)['texture'])
+        tex_data.set_status(imgui.ImTextureStatus.ok)
+
+    def render(self, draw_data: imgui.ImDrawData | None = None):
+        self.ctx.new_frame(clear=False)
+
+        if self.io.fonts.tex_data.status == imgui.ImTextureStatus.want_updates:
+            # the internal imgui_bundle atlas changes dynamically
+            # so we need to update it or we end up with missing glyphs
+            self._update_font_texture()
+
         if draw_data is None:
             draw_data = imgui.get_draw_data()
 
         display_width, display_height = self.io.display_size
-        fb_width = int(display_width * self.io.display_fb_scale[0])
-        fb_height = int(display_height * self.io.display_fb_scale[1])
+        fb_width = int(display_width * self.io.display_framebuffer_scale[0])
+        fb_height = int(display_height * self.io.display_framebuffer_scale[1])
 
         if draw_data is None or fb_width == 0 or fb_height == 0:
             return
@@ -135,27 +154,42 @@ class ZenGLRenderer:
         gl = self.gl
         gl.glEnable(gl.GL_SCISSOR_TEST)
         gl.glActiveTexture(gl.GL_TEXTURE0)
-        for commands in draw_data.commands_lists:
+        for commands in draw_data.cmd_lists:
             idx_buffer_offset = 0
-            vtx_size = commands.vtx_buffer_size * imgui.VERTEX_SIZE
-            idx_size = commands.idx_buffer_size * imgui.INDEX_SIZE
+            vtx_size = commands.vtx_buffer.size() * imgui.VERTEX_SIZE
+            idx_size = commands.idx_buffer.size() * imgui.INDEX_SIZE
+            vtx_buffer_data = (c_byte * vtx_size).from_address(commands.vtx_buffer.data_address())
+            idx_buffer_data = (c_byte * idx_size).from_address(commands.idx_buffer.data_address())
             gl.glBindBuffer(gl.GL_ARRAY_BUFFER, self.vtx_buffer)
-            gl.glBufferData(gl.GL_ARRAY_BUFFER, vtx_size, commands.vtx_buffer_data, gl.GL_STREAM_DRAW)
+            gl.glBufferData(gl.GL_ARRAY_BUFFER, vtx_size, vtx_buffer_data, gl.GL_STREAM_DRAW)
             gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.idx_buffer)
-            gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, idx_size, commands.idx_buffer_data, gl.GL_STREAM_DRAW)
-            for command in commands.commands:
+            gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, idx_size, idx_buffer_data, gl.GL_STREAM_DRAW)
+            for command in commands.cmd_buffer:
                 x1, y1, x2, y2 = command.clip_rect
                 gl.glScissor(int(x1), int(fb_height - y2), int(x2 - x1), int(y2 - y1))
-                gl.glBindTexture(gl.GL_TEXTURE_2D, command.texture_id)
+                gl.glBindTexture(gl.GL_TEXTURE_2D, command.get_tex_id())
                 gl.glDrawElementsInstanced(gl.GL_TRIANGLES, command.elem_count, gl.GL_UNSIGNED_INT, idx_buffer_offset, 1)
                 idx_buffer_offset += command.elem_count * imgui.INDEX_SIZE
         gl.glDisable(gl.GL_SCISSOR_TEST)
 
+        self.ctx.end_frame()
+
 
 class PygameBackend:
     def __init__(self):
+        # monkey patch fix for broken OpenGL backend import within imgui_bundle
+        # we only care about the input/event handling from PygameRenderer
+        # so we can safely just replace it with a noop
+        import sys, types
+        _fake_mod = types.ModuleType("imgui_bundle.python_backends.opengl_backend_fixed")
+        class FixedPipelineRenderer:
+            pass
+        _fake_mod.FixedPipelineRenderer = FixedPipelineRenderer
+        sys.modules["imgui_bundle.python_backends.opengl_backend_fixed"] = _fake_mod
+
         import pygame
-        from imgui.integrations.pygame import PygameRenderer
+        from imgui_bundle.python_backends.python_backends_disabled.pygame_backend import PygameRenderer
+
         class PygameInputHandler(PygameRenderer):
             def __init__(self):
                 self._gui_time = None
@@ -169,8 +203,8 @@ class PygameBackend:
         self.input_handler = PygameInputHandler()
         self.renderer = ZenGLRenderer()
 
-    def render(self):
-        return self.renderer.render()
+    def render(self, draw_data: imgui.ImDrawData | None = None):
+        return self.renderer.render(draw_data)
 
     def process_event(self, event):
         return self.input_handler.process_event(event)


### PR DESCRIPTION
Port `pyimgui` to `imgui_bundle` as discussed in https://github.com/szabolcsdombi/zengl-imgui/issues/4

1) Most of the actual renderer changes are just naming/access differences for the API changes that imgui_bundle has made

2) The imgui internal font texture seems to work a bit differently, the atlas is only partially built on init, when new glyphs appear in frame the flag changes for `self.io.fonts.tex_data.status == imgui.ImTextureStatus.want_updates` and we need to execute the `_update_font_texture` helper method based on this.

3) I saw the `self.ctx.new_frame(clear=False)` and `self.ctx.end_frame(flush=False)` lines on the [moderngl example](https://github.com/moderngl/moderngl/blob/main/examples/imgui_integration.py), so I added that into the core rendering so that moderngl would not need to do the subclass step
   - ^ seems to work fine with both `zengl` and `pyopengl` from my testing with these included, not sure if you know of a reason to only include them with `moderngl` and remove from here?

4) Updated the included zengl example to include some background color, and added an example for moderngl and pyopengl

5) The `imgui_bundle` core maintainer is no longer maintaining the `PygameRenderer` module, and there's a broken import in it that prevents importing, so I've included a funky hack in here to patch it
    - I raised an issue [here](https://github.com/pthom/imgui_bundle/issues/369) though on the `imgui_bundle` repo offering to raise a PR to fix it which is welcomed, so I'll submit this PR soon and we can remove this override from here
    - There's also a small bug in imgui_bundle blocking space bar having effect when inputting text to text input widgets, I'll fix this in the same PR

6) Question - do you think we should maintain backwards compat for `pyimgui` with Python 3.12, by keeping the previous/existing ZenglRenderer module and falling back to it upon detecting the installed old pyimgui version? Or just have this library support `imgui_bundle` only?